### PR TITLE
Amendments and bug-fixes

### DIFF
--- a/src/variable_interpolation/error.rs
+++ b/src/variable_interpolation/error.rs
@@ -1,6 +1,6 @@
 //! contains the error type used by the variable interpolation parser
 //!
-//! since the calling code expects the error type to be serde_yaml::Error,
+//! since the calling code expects the error type to be `serde_yaml::Error`,
 //! `ParseError` can be converted to that type, using the error information
 //! to construct a custom error message
 

--- a/src/variable_interpolation/parser.rs
+++ b/src/variable_interpolation/parser.rs
@@ -261,15 +261,12 @@ impl<'s> Parser<'s> {
             _ => ModifierCondition::WhenUnset,
         };
 
-        let mut mod_val = String::new();
         let modifier: Modifier = match self.rest.next() {
             Some('-') => {
-                self.parse_modifier_value(&mut mod_val)?;
-                DefaultValue(cond, mod_val)
+                DefaultValue(cond, self.parse_modifier_value()?)
             }
             Some('?') => {
-                self.parse_modifier_value(&mut mod_val)?;
-                ErrorMessage(cond, mod_val)
+                ErrorMessage(cond, self.parse_modifier_value()?)
             }
             Some(character) => terminate!(self, "expected one of ? or -, got {}", character),
             None => terminate!(self, "input ended unexpectedly"),
@@ -279,7 +276,8 @@ impl<'s> Parser<'s> {
     }
 
     /// parse the contents of the error message or default value of a braced variable
-    fn parse_modifier_value(&mut self, output: &mut String) -> Result {
+    fn parse_modifier_value(&mut self) -> std::result::Result<String, ParseError> {
+        let mut output = String::new();
         loop {
             match self.rest.peek() {
                 Some('}') => {
@@ -294,7 +292,7 @@ impl<'s> Parser<'s> {
                 None => terminate!(self, "input ended unexpectedly"),
             }
         }
-        Ok(())
+        Ok(output)
     }
 }
 

--- a/src/variable_interpolation/parser.rs
+++ b/src/variable_interpolation/parser.rs
@@ -5,7 +5,7 @@ use super::VariableResolver;
 use std::{iter::Peekable, str::Chars};
 
 /// the result type for the parser
-type Result = std::result::Result<(), ParseError>;
+type Result<T> = std::result::Result<T, ParseError>;
 
 #[derive(Debug, Clone)]
 /// the struct containing the state of the parser during the parsing process
@@ -59,7 +59,7 @@ impl<'s> Parser<'s> {
 
     /// entry point into the parsing logic. after this returns Ok, self.output
     /// contains the interpolated input string.
-    fn parse_string(&mut self) -> Result {
+    fn parse_string(&mut self) -> Result<()> {
         loop {
             if self.rest.peek().is_none() {
                 // nothing to parse anymore, we're done
@@ -74,7 +74,7 @@ impl<'s> Parser<'s> {
     }
 
     /// parse either the start of a variable name ($) or an escaped dollar sign ($$)
-    fn parse_variable_start(&mut self) -> Result {
+    fn parse_variable_start(&mut self) -> Result<()> {
         // check that the iterator points to a $ and consume it
         match self.rest.peek() {
             Some('$') => {
@@ -108,7 +108,7 @@ impl<'s> Parser<'s> {
     }
 
     /// parse a braced variable: `{NAME}`
-    fn parse_braced_variable_start(&mut self) -> Result {
+    fn parse_braced_variable_start(&mut self) -> Result<()> {
         // check that the iterator points to a `{`
         match self.rest.next() {
             Some('{') => {}
@@ -119,7 +119,7 @@ impl<'s> Parser<'s> {
     }
 
     /// parse the name of an unbraced variable and replace it with its value
-    fn parse_variable_name(&mut self) -> Result {
+    fn parse_variable_name(&mut self) -> Result<()> {
         let mut name = String::new();
         match self.rest.next() {
             Some(character @ ('_' | 'a'..='z' | 'A'..='Z')) => name.push(character),
@@ -149,7 +149,7 @@ impl<'s> Parser<'s> {
     }
 
     /// parse a braced variable name and push the associated value into `output`
-    fn parse_braced_variable_name(&mut self) -> Result {
+    fn parse_braced_variable_name(&mut self) -> Result<()> {
         let mut name = String::new();
         self.consume_whitespace();
         // the next character should be the start of a variable name.
@@ -249,7 +249,7 @@ impl<'s> Parser<'s> {
     }
 
     /// check for a modifier or default value. these can contain nested variables.
-    fn parse_modifier(&mut self) -> std::result::Result<Modifier, ParseError> {
+    fn parse_modifier(&mut self) -> Result<Modifier> {
         use Modifier::{DefaultValue, ErrorMessage};
 
         let cond = match self.rest.peek() {
@@ -276,7 +276,7 @@ impl<'s> Parser<'s> {
     }
 
     /// parse the contents of the error message or default value of a braced variable
-    fn parse_modifier_value(&mut self) -> std::result::Result<String, ParseError> {
+    fn parse_modifier_value(&mut self) -> Result<String> {
         let mut output = String::new();
         loop {
             match self.rest.peek() {

--- a/src/variable_interpolation/parser.rs
+++ b/src/variable_interpolation/parser.rs
@@ -189,20 +189,21 @@ impl<'s> Parser<'s> {
                             modifier.replace(self.parse_modifier()?);
                             break;
                         }
-                        Some(&c) => {
-                            terminate!(self, "expected one of }}:?- , got {}", c);
+                        Some(&char) => {
+                            terminate!(self, "expected one of }}:?- , got {}", char);
                         }
                         None => terminate!(self, "input ended unexpectedly"),
                     }
                 }
-                Some(c) => {
-                    name.push(*c);
+                Some(char) => {
+                    name.push(*char);
                     self.rest.next();
                 }
                 None => terminate!(self, "input ended unexpectedly"),
             }
         }
 
+        #[allow(clippy::single_match_else)]
         let value: &str = match self.env.get(&name) {
             Some(value) => {
                 if value.is_empty() {
@@ -243,7 +244,7 @@ impl<'s> Parser<'s> {
     fn consume_whitespace(&mut self) {
         while self
             .rest
-            .next_if(|c: &char| char::is_whitespace(*c))
+            .next_if(|char: &char| char::is_whitespace(*char))
             .is_some()
         {}
     }

--- a/src/variable_interpolation/yaml_walk.rs
+++ b/src/variable_interpolation/yaml_walk.rs
@@ -18,7 +18,7 @@ pub(crate) fn interpolate_value(
         YamlValue::Sequence(sequence) => interpolate_sequence(vars, sequence)?,
         YamlValue::Mapping(mapping) => interpolate_mapping(vars, mapping)?,
         _ => {}
-    };
+    }
     Ok(())
 }
 


### PR DESCRIPTION
Fixes a bug where the name of a braced variable could be closed with whitespace. I can't say that style changes are objectively better, but I tried to reflect the algorithmic logic in the semantics.
- **Add and fix a whitespace test** (Fixes a bug where the name of a braced variable could be closed with whitespace)
- **Style changes** ( I can't say that style changes are objectively better, but I tried to reflect the algorithmic logic in the semantics.)
- **Change signature of parse_modifier_value**
- **Add type argument to parser Result type**
- **Add test** (proves that an unbraced variable can't start with a numeric character)
